### PR TITLE
fix: add Docker healthcheck directives for api and web services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,12 @@ services:
       API_LOG_LEVEL: info
       MENTION_TIMEOUT_MS: 300000
       WEB_URL: http://localhost:5173
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:3000/health || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
     depends_on:
       postgres:
         condition: service_healthy
@@ -32,8 +38,15 @@ services:
       - "5173:80"
     environment:
       VITE_API_URL: http://localhost:3000
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:80/ || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
     depends_on:
-      - api
+      api:
+        condition: service_healthy
 
   postgres:
     image: postgres:17-alpine

--- a/packages/api/src/routes/health.ts
+++ b/packages/api/src/routes/health.ts
@@ -33,6 +33,6 @@ export default async function healthRoutes(fastify: FastifyInstance) {
       return reply.status(503).send({ status: 'not_ready', reason: 'redis' });
     }
 
-    return { status: 'ready' };
+    return { status: 'ready', db: true, redis: true };
   });
 }


### PR DESCRIPTION
Fixes #6

## Changes

**`docker-compose.yml`**
- Added `healthcheck` for **api** service: `wget -qO- http://localhost:3000/health` (10s interval, 5s timeout, 5 retries, 15s start period)
- Added `healthcheck` for **web** service: `wget -qO- http://localhost:80/` (10s interval, 5s timeout, 5 retries, 10s start period)
- Changed `web.depends_on` from simple `- api` to `api: condition: service_healthy` so web waits for api to be healthy
- Uses `wget` instead of `curl` since both containers use Alpine base images

**`packages/api/src/routes/health.ts`**
- `/ready` endpoint now returns `{ status: "ready", db: true, redis: true }` instead of just `{ status: "ready" }`

## How to test
```bash
docker compose up
docker compose ps   # All services should show 'healthy'
curl http://localhost:3000/health   # { "status": "ok", "timestamp": "..." }
curl http://localhost:3000/ready    # { "status": "ready", "db": true, "redis": true }
```

Postgres and Redis already had healthchecks (pg_isready and redis-cli ping) — no changes needed there.