### PR TITLE
fix: expose rate limit headers in API responses

### DIFF
--- a/packages/api/src/plugins/rate-limit.ts
+++ b/packages/api/src/plugins/rate-limit.ts
@@ -7,6 +7,17 @@ export default fp(
     await fastify.register(rateLimit, {
       max: 100,
       timeWindow: '1 minute',
+      addHeaders: {
+        'x-ratelimit-limit': true,
+        'x-ratelimit-remaining': true,
+        'x-ratelimit-reset': true,
+        'retry-after': true,
+      },
+      addHeadersOnExceeding: {
+        'x-ratelimit-limit': true,
+        'x-ratelimit-remaining': true,
+        'x-ratelimit-reset': true,
+      },
     });
   },
   { name: 'rate-limit' },


### PR DESCRIPTION
## Summary

Closes #9

The `@fastify/rate-limit` plugin (already a dependency) supports `addHeaders` and `addHeadersOnExceeding` config options but they were not enabled. This adds:

- `x-ratelimit-limit` — the configured max requests per window
- `x-ratelimit-remaining` — requests left in the current window
- `x-ratelimit-reset` — Unix timestamp when the window resets
- `retry-after` — seconds until the limit resets (only on 429 responses)

## Changes

`packages/api/src/plugins/rate-limit.ts` — added `addHeaders` and `addHeadersOnExceeding` config to the plugin registration.

## How to test

```bash
curl -v http://localhost:3000/health 2>&1 | grep -i ratelimit
# Expected: x-ratelimit-limit: 100, x-ratelimit-remaining: 99, x-ratelimit-reset: <timestamp>
```