### PR TITLE
feat: add /help slash command listing all available commands

### DIFF
--- a/packages/web/src/utils/slash-commands.ts
+++ b/packages/web/src/utils/slash-commands.ts
@@ -136,6 +136,22 @@ export const SLASH_COMMANDS: SlashCommand[] = [
       return { handled: true, message: `DM sent to ${match[1]}` };
     },
   },
+  {
+    name: '/help',
+    description: 'Show available commands',
+    usage: '/help',
+    handler: async (_args, ctx) => {
+      const lines = ['**Available commands:**'];
+      for (const cmd of SLASH_COMMANDS) {
+        lines.push(`\`${cmd.usage}\` — ${cmd.description}`);
+      }
+      await api.post('/v1/messages', {
+        channelId: ctx.channelId,
+        content: lines.join('\n'),
+      });
+      return { handled: true };
+    },
+  },
 ];
 
 export function parseSlashCommand(input: string): { command: SlashCommand; args: string } | null {


### PR DESCRIPTION
## Summary

Closes #5

Adds a `/help` slash command that posts a formatted message listing every available command with its usage syntax and description. This helps new users discover commands without having to read external documentation.

## Changes

`packages/web/src/utils/slash-commands.ts` — added a `/help` entry to `SLASH_COMMANDS`. The handler iterates the existing array so the list stays in sync automatically when new commands are added.

## How to test

Type `/help` in any channel and send. A message appears listing all commands:

```
**Available commands:**
`/assign @name Task description` — Assign a task to someone
`/approve action-type Description of what needs approval` — Request approval for an action
`/doc Title of the document` — Create a channel doc
`/webhook Webhook Name` — Create a webhook for this channel
`/status Your status message` — Set your status message
`/dnd` — Set Do Not Disturb
`/dm @name Your message` — Send a direct message
`/help` — Show available commands
```